### PR TITLE
Add writeFile to public API

### DIFF
--- a/Sources/Citadel/SFTP/SFTPClient.swift
+++ b/Sources/Citadel/SFTP/SFTPClient.swift
@@ -84,6 +84,24 @@ public final class SFTPClient {
         }
     }
     
+    func writeFile(
+        handle: ByteBuffer,
+        data: ByteBuffer,
+        offset: UInt64,
+        length: UInt32
+    ) -> EventLoopFuture<Void> {
+        return sendRequest(
+            .write(
+                .init(
+                    requestId: nextRequestId(),
+                    handle: handle,
+                    offset: offset,
+                    data: data
+                )
+            )
+        ).map { _ in }
+    }
+    
     public func openFile(
         filePath: String,
         flags: SFTPOpenFileFlags,

--- a/Sources/Citadel/SFTP/SFTPFile.swift
+++ b/Sources/Citadel/SFTP/SFTPFile.swift
@@ -7,4 +7,8 @@ public struct SFTPFile {
     public func read(from offset: UInt64 = 0, length: UInt32) -> EventLoopFuture<ByteBuffer> {
         client.readFile(handle: handle, offset: offset, length: length)
     }
+    
+    public func write(from offset: UInt64 = 0, length: UInt32, data: ByteBuffer) -> EventLoopFuture<Void> {
+        client.writeFile(handle: handle, data: data, offset: offset, length: length)
+    }
 }


### PR DESCRIPTION
Adds the `writeFile` method, which returns `EventLoopFuture<Void>`, so that users can create files as well as read them. 